### PR TITLE
Add CI for eks-auto-drain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,70 @@
+name: Build & Publish to S3
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run SAM build
+        uses: TractorZoom/sam-cli-action@master
+        with:
+          sam_command: "build"
+      - name: Archive build
+        uses: montudor/action-zip@v0.1.0
+        with:
+          args: zip -qq -r aws-sam.zip README.md .aws-sam
+      - name: Upload build archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: aws-sam
+          path: aws-sam.zip
+  publish-to-s3:
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      matrix:
+        include:
+          - region: cmh
+            aws_region: us-east-2
+          - region: dub
+            aws_region: eu-west-1
+          - region: iad
+            aws_region: us-east-1
+          - region: syd
+            aws_region: ap-southeast-2
+    steps:
+      - name: Download build archive
+        uses: actions/download-artifact@v2
+        with:
+          name: aws-sam
+      - name: Unzip build archive
+        uses: montudor/action-zip@v0.1.0
+        with:
+          args: unzip -qq aws-sam.zip
+      - name: Publish to S3 (${{ matrix.region }})
+        uses: TractorZoom/sam-cli-action@master
+        with:
+          sam_command: "package --output-template-file packaged.yaml --s3-bucket truss-eks-auto-drain-${{ matrix.region }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ matrix.aws_region }}
+      - name: Extract artifact metadata
+        id: artifact-metadata
+        run: |
+          s3_path=$(grep CodeUri packaged.yaml | cut -d'/' -f4)
+          echo "::set-output name=s3_path::$s3_path"
+          echo "Lambda Package S3 Key: $s3_path"
+        shell: bash
+      - name: Update current package revision on merge to master
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{steps.artifact-metadata.outputs.s3_path}} > s3_path.txt
+          aws s3 cp ./s3_path.txt s3://truss-eks-auto-drain-${{ matrix.region }}/current
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ matrix.aws_region }}
+    outputs:
+      artifact_s3_path: ${{ steps.artifact-metadata.outputs.s3_path }}

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,6 @@ Metadata:
     Description: Drains an EKS Worker Node when invoked by a CloudWatch event matching an Auto Scaling Group instance-terminating lifecycle action
     Author: Derek Keightley
     SpdxLicenseId: MIT
-    LicenseUrl: LICENSE
     ReadmeUrl: README.md
     Labels: ['eks', 'asg', 'lambda', 'kubernetes']
     HomePageUrl: https://github.com/dkeightley/eks-auto-drain

--- a/template.yaml
+++ b/template.yaml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: lambda_function.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.8
       Timeout: 600
       Policies:
         - Version: '2012-10-17'


### PR DESCRIPTION
This workflow run a single build job of eks-auto-drain, uploads the artifact, then uses it in 4 parallel jobs to package to S3 buckets in each applicable region. We also grab the hash/s3 path where the artifact was uploaded to as an output for future CD use.